### PR TITLE
Child lifetime scopes

### DIFF
--- a/src/kanata/iinjectable_catalog.py
+++ b/src/kanata/iinjectable_catalog.py
@@ -1,6 +1,6 @@
 from .models import InjectableRegistration
 from abc import ABCMeta, abstractmethod
-from typing import Any, Iterable, Optional, Type, TypeVar
+from typing import Any, Optional, Tuple, Type, TypeVar
 
 T = TypeVar("T")
 
@@ -8,23 +8,23 @@ class IInjectableCatalog(metaclass=ABCMeta):
     """Interface for a catalog of injectable registrations."""
 
     @abstractmethod
-    def get_registrations(self) -> Iterable[InjectableRegistration]:
+    def get_registrations(self) -> Tuple[InjectableRegistration, ...]:
         """Gets all the registrations available in the catalog.
 
         :return: The available registrations.
-        :rtype: Iterable[InjectableRegistration]
+        :rtype: Tuple[InjectableRegistration, ...]
         """
 
     @abstractmethod
     def get_registrations_by_contract(
         self,
-        contract: Type[Any]) -> Iterable[InjectableRegistration]:
+        contract: Type[Any]) -> Tuple[InjectableRegistration, ...]:
         """Gets the registrations associated to the specified contract.
 
         :param contract: The contract for which to get the registrations.
         :type contract: Type[Any]
         :return: The registrations associated to the contract.
-        :rtype: Iterable[InjectableRegistration]
+        :rtype: Tuple[InjectableRegistration, ...]
         """
 
     @abstractmethod

--- a/src/kanata/ilifetime_scope.py
+++ b/src/kanata/ilifetime_scope.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from abc import ABCMeta, abstractmethod
 from typing import Type, TypeVar
 
@@ -18,4 +19,15 @@ class ILifetimeScope(metaclass=ABCMeta):
         :raises DependencyResolutionException: Raised when dependency resolution fails.
         :return: An instance of the appropriate injectable.
         :rtype: TInjectable
+        """
+
+    @abstractmethod
+    def create_child_scope(self) -> ILifetimeScope:
+        """Creates a lifetime scoped attached to the current one.
+        This child will have access to the same injectable catalog,
+        as well as singleton instances. Scoped instances will die
+        along with this child.
+
+        :return: A lifetime scope attached to the current lifetime scope.
+        :rtype: ILifetimeScope
         """

--- a/src/kanata/injectable_catalog.py
+++ b/src/kanata/injectable_catalog.py
@@ -1,7 +1,7 @@
 from .iinjectable_catalog import IInjectableCatalog
 from .models import InjectableRegistration
 from kanata.utils import get_or_add
-from typing import Any, Dict, Iterable, List, Optional, Type
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
 
 class InjectableCatalog(IInjectableCatalog):
     """Provides access to information about the known injectables."""
@@ -11,12 +11,12 @@ class InjectableCatalog(IInjectableCatalog):
         self.__registrations_by_injectable: Dict[Type[Any], InjectableRegistration] = {}
         self.__build_registration_maps(registrations)
 
-    def get_registrations(self) -> Iterable[InjectableRegistration]:
-        return self.__registrations_by_injectable.values()
+    def get_registrations(self) -> Tuple[InjectableRegistration, ...]:
+        return tuple(self.__registrations_by_injectable.values())
 
     def get_registrations_by_contract(
         self,
-        contract: Type[Any]) -> Iterable[InjectableRegistration]:
+        contract: Type[Any]) -> Tuple[InjectableRegistration, ...]:
         return tuple(self.__registrations_by_contract.get(contract, []))
 
     def get_registration_by_injectable(

--- a/src/kanata/lifetime_scope.py
+++ b/src/kanata/lifetime_scope.py
@@ -176,7 +176,7 @@ class LifetimeScope(ILifetimeScope):
             candidate_instances = []
             for registration in registrations:
                 if (dependee_scope == InjectableScopeType.SINGLETON
-                    and registration.scope == InjectableScopeType.TRANSIENT):
+                    and registration.scope != InjectableScopeType.SINGLETON):
                     self.__on_captive_dependency_detected(injectable, dependent_contract)
 
                 scope = get_or_add(self.__instances_by_injectable, registration.scope, lambda _: {})

--- a/src/kanata/lifetime_scope.py
+++ b/src/kanata/lifetime_scope.py
@@ -6,7 +6,7 @@ from .iinjectable_catalog import IInjectableCatalog
 from .ilifetime_scope import ILifetimeScope, TInjectable
 from .models import InjectableScopeType, LifetimeScopeOptions
 from .utils import get_or_add
-from typing import Any, Dict, Generator, List, Set, Tuple, Type, get_args
+from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Type, get_args
 
 import inspect
 import structlog
@@ -20,13 +20,26 @@ class LifetimeScope(ILifetimeScope):
 
     def __init__(self,
                  catalog: IInjectableCatalog,
-                 options: LifetimeScopeOptions = DEFAULT_OPTIONS) -> None:
+                 options: LifetimeScopeOptions = DEFAULT_OPTIONS,
+                 **kwargs: Any) -> None:
         self.__catalog: IInjectableCatalog = catalog
         self.__options: LifetimeScopeOptions = options
         self.__log = structlog.get_logger(LOGGER_NAME)
         self.__instances_by_injectable: Dict[InjectableScopeType, Dict[Type[Any], Set[Any]]] = {}
+        self.__parent: Optional[ILifetimeScope] = None
+
+        if (parent := kwargs.get("parent", None)) is not None:
+            if not isinstance(parent, ILifetimeScope):
+                raise ValueError("The parent must be an instance of ILifetimeScope.")
+            self.__parent = parent
 
     def resolve(self, injectable: Type[TInjectable]) -> TInjectable:
+        registration = self.__catalog.get_registration_by_injectable(injectable)
+        if (registration is not None
+            and registration.scope == InjectableScopeType.SINGLETON
+            and self.__parent is not None):
+            return self.__parent.resolve(injectable)
+
         dependency_graph = self.__build_dependency_graph_for(injectable)
         instance = None
         for current_injectable in topological_sort(dependency_graph, injectable):
@@ -44,6 +57,9 @@ class LifetimeScope(ILifetimeScope):
             )
 
         return instance
+
+    def create_child_scope(self) -> ILifetimeScope:
+        return LifetimeScope(self.__catalog, self.__options, parent=self)
 
     @staticmethod
     def __get_dependent_contracts(
@@ -133,15 +149,16 @@ class LifetimeScope(ILifetimeScope):
                 )
             )
 
-        # For singletons, we know that there exists one instance and one instance only
-        # for all of the associated contracts, therefore we can find and return that one,
-        # if it is created already.
+        # For singleton and scoped injectables, we know that there exists one and only one
+        # instance for all of the associated contracts, therefore we can find and return
+        # taht specific one if it is created already.
         scope_by_injectable = get_or_add(
             self.__instances_by_injectable,
             registration.scope,
             lambda _: {})
         instances_by_injectable = get_or_add(scope_by_injectable, injectable, lambda _: set())
-        if registration.scope == InjectableScopeType.SINGLETON:
+        if (registration.scope == InjectableScopeType.SINGLETON
+            or registration.scope == InjectableScopeType.SCOPED):
             if len(instances_by_injectable) > 0:
                 return next(iter(instances_by_injectable))
 

--- a/src/kanata/models/injectable_scope_type.py
+++ b/src/kanata/models/injectable_scope_type.py
@@ -10,5 +10,13 @@ class InjectableScopeType(IntEnum):
 
     SINGLETON = 1
     """Marks the injectable as a singleton,
-    meaning it persists throughout an entire lifetime scope.
+    meaning the same single instance is returned for
+    each request from a lifetime scope and
+    all of its child lifetime scopes.
+    """
+
+    SCOPED = 2
+    """Marks the injectable as scoped,
+    meaning a new instance is created for each lifetime scope,
+    even the children of a parent lifetime scope (contrary to singletons).
     """

--- a/tests/unit/test_injectables/__init__.py
+++ b/tests/unit/test_injectables/__init__.py
@@ -1,6 +1,7 @@
 from .captive_dependency import CaptiveDependency
 from .inon_dependee import INonDependee
 from .iroot import IRoot
+from .iscoped import IScoped
 from .isingleton import ISingleton
 from .itransient1 import ITransient1
 from .itransient2 import ITransient2
@@ -8,6 +9,7 @@ from .iunused import IUnused
 from .missing_multiple_dependencies import MissingMultipleDependencies
 from .missing_single_dependency import MissingSingleDependency
 from .root import Root
+from .scoped import Scoped
 from .singleton import Singleton
 from .transient1 import Transient1
 from .transient2 import Transient2

--- a/tests/unit/test_injectables/__init__.py
+++ b/tests/unit/test_injectables/__init__.py
@@ -1,4 +1,5 @@
-from .captive_dependency import CaptiveDependency
+from .captive_scoped_dependency import CaptiveScopedDependency
+from .captive_transient_dependency import CaptiveTransientDependency
 from .inon_dependee import INonDependee
 from .iroot import IRoot
 from .iscoped import IScoped

--- a/tests/unit/test_injectables/captive_scoped_dependency.py
+++ b/tests/unit/test_injectables/captive_scoped_dependency.py
@@ -1,0 +1,12 @@
+from .inon_dependee import INonDependee
+from .iscoped import IScoped
+from kanata.decorators import injectable, scope
+from kanata.models import InjectableScopeType
+
+@scope(InjectableScopeType.SINGLETON)
+@injectable(INonDependee)
+class CaptiveScopedDependency(INonDependee):
+    """A singleton dependent type that depends on a scoped instance."""
+
+    def __init__(self, scoped: IScoped) -> None: # pylint: disable=unused-argument
+        super().__init__()

--- a/tests/unit/test_injectables/captive_transient_dependency.py
+++ b/tests/unit/test_injectables/captive_transient_dependency.py
@@ -5,7 +5,7 @@ from kanata.models import InjectableScopeType
 
 @scope(InjectableScopeType.SINGLETON)
 @injectable(INonDependee)
-class CaptiveDependency(INonDependee):
+class CaptiveTransientDependency(INonDependee):
     """A singleton dependent type that depends on a transient instance."""
 
     def __init__(self, transient: ITransient1) -> None: # pylint: disable=unused-argument

--- a/tests/unit/test_injectables/iscoped.py
+++ b/tests/unit/test_injectables/iscoped.py
@@ -1,0 +1,4 @@
+from abc import ABCMeta
+
+class IScoped(metaclass=ABCMeta):
+    """Interface for a scoped injectable."""

--- a/tests/unit/test_injectables/scoped.py
+++ b/tests/unit/test_injectables/scoped.py
@@ -1,0 +1,8 @@
+from .iscoped import IScoped
+from kanata.decorators import injectable, scope
+from kanata.models import InjectableScopeType
+
+@scope(InjectableScopeType.SCOPED)
+@injectable(IScoped)
+class Scoped(IScoped):
+    """A scoped injectable for testing."""

--- a/tests/unit/test_lifetime_scope.py
+++ b/tests/unit/test_lifetime_scope.py
@@ -1,6 +1,6 @@
 from .test_injectables import (
-    CaptiveDependency, MissingMultipleDependencies, MissingSingleDependency,
-    Scoped, Singleton, Root, Transient1, Transient2
+    CaptiveScopedDependency, CaptiveTransientDependency, MissingMultipleDependencies,
+    MissingSingleDependency, Scoped, Singleton, Root, Transient1, Transient2
 )
 from kanata import InjectableCatalog, LifetimeScope, find_injectables
 from kanata.exceptions import DependencyResolutionException
@@ -68,7 +68,7 @@ class LifetimeScopeTests(unittest.TestCase):
             DependencyResolutionException,
             lambda: scope.resolve(MissingSingleDependency))
 
-    def test_resolve_should_raise_with_singleton_captive_dependency(self):
+    def test_resolve_should_raise_with_singleton_captive_transient_dependency(self):
         """Asserts that a singleton injectable that has a transient dependency
         raises an exception with the default options.
         """
@@ -77,9 +77,26 @@ class LifetimeScopeTests(unittest.TestCase):
         catalog = InjectableCatalog(registrations)
         scope = LifetimeScope(catalog)
 
-        self.assertRaises(DependencyResolutionException, lambda: scope.resolve(CaptiveDependency))
+        self.assertRaises(
+            DependencyResolutionException,
+            lambda: scope.resolve(CaptiveTransientDependency)
+        )
 
-    def test_resolve_should_resolve_with_singleton_captive_dependency_when_permitted(self):
+    def test_resolve_should_raise_with_singleton_captive_scoped_dependency(self):
+        """Asserts that a singleton injectable that has a scoped dependency
+        raises an exception with the default options.
+        """
+
+        registrations = find_injectables("tests.unit.test_injectables")
+        catalog = InjectableCatalog(registrations)
+        scope = LifetimeScope(catalog)
+
+        self.assertRaises(
+            DependencyResolutionException,
+            lambda: scope.resolve(CaptiveScopedDependency)
+        )
+
+    def test_resolve_should_resolve_with_singleton_captive_transient_dependency_when_permitted(self):
         """Asserts that a singleton injectable that has a transient dependency
         resolves just fine when permitted via the lifetime scope options.
         """
@@ -89,7 +106,21 @@ class LifetimeScopeTests(unittest.TestCase):
         catalog = InjectableCatalog(registrations)
         scope = LifetimeScope(catalog, options)
 
-        instance = scope.resolve(CaptiveDependency)
+        instance = scope.resolve(CaptiveTransientDependency)
+
+        self.assertIsNotNone(instance)
+
+    def test_resolve_should_resolve_with_singleton_captive_scoped_dependency_when_permitted(self):
+        """Asserts that a singleton injectable that has a scoped dependency
+        resolves just fine when permitted via the lifetime scope options.
+        """
+
+        registrations = find_injectables("tests.unit.test_injectables")
+        options = LifetimeScopeOptions(raise_on_captive_dependency=False)
+        catalog = InjectableCatalog(registrations)
+        scope = LifetimeScope(catalog, options)
+
+        instance = scope.resolve(CaptiveScopedDependency)
 
         self.assertIsNotNone(instance)
 

--- a/tests/unit/test_service_discovery.py
+++ b/tests/unit/test_service_discovery.py
@@ -1,8 +1,8 @@
 from kanata import find_injectables
 from tests.sdk import assert_contains_all, first
 from tests.unit.test_injectables import (
-    INonDependee, IRoot, IScoped, ISingleton, ITransient1, ITransient2,
-    CaptiveDependency, MissingMultipleDependencies, MissingSingleDependency,
+    INonDependee, IRoot, IScoped, ISingleton, ITransient1, ITransient2, CaptiveScopedDependency,
+    CaptiveTransientDependency, MissingMultipleDependencies, MissingSingleDependency,
     Root, Scoped, Singleton, Transient1, Transient2
 )
 from typing import Any, Dict, Tuple, Type
@@ -22,7 +22,8 @@ class ServiceDiscoveryTests(unittest.TestCase):
             Transient2: (ITransient2,),
             MissingMultipleDependencies: (INonDependee,),
             MissingSingleDependency: (INonDependee,),
-            CaptiveDependency: (INonDependee,),
+            CaptiveScopedDependency: (INonDependee,),
+            CaptiveTransientDependency: (INonDependee,),
             Scoped: (IScoped,)
         }
 

--- a/tests/unit/test_service_discovery.py
+++ b/tests/unit/test_service_discovery.py
@@ -1,9 +1,9 @@
 from kanata import find_injectables
 from tests.sdk import assert_contains_all, first
 from tests.unit.test_injectables import (
-    INonDependee, IRoot, ISingleton, ITransient1, ITransient2,
+    INonDependee, IRoot, IScoped, ISingleton, ITransient1, ITransient2,
     CaptiveDependency, MissingMultipleDependencies, MissingSingleDependency,
-    Root, Singleton, Transient1, Transient2
+    Root, Scoped, Singleton, Transient1, Transient2
 )
 from typing import Any, Dict, Tuple, Type
 
@@ -22,7 +22,8 @@ class ServiceDiscoveryTests(unittest.TestCase):
             Transient2: (ITransient2,),
             MissingMultipleDependencies: (INonDependee,),
             MissingSingleDependency: (INonDependee,),
-            CaptiveDependency: (INonDependee,)
+            CaptiveDependency: (INonDependee,),
+            Scoped: (IScoped,)
         }
 
         registrations = find_injectables("tests.unit.test_injectables")


### PR DESCRIPTION
Introduces the `SCOPED` lifetime scope type which works in tandem with the also newly introduced child lifetime scopes. Marking an injectable as `SCOPED` will make each lifetime scope return a new instance. This is similar to `SINGLETON` injectables but whereas a `SINGLETON` injectable has one single instance per lifetime scope tree - which is managed by the root lifetime scope -, a `SCOPED` injectable has multiple instances - one in each lifetime scope of the lifetime scope tree.

For example:
```py
# Collect all of our injectables and build a catalog
registrations = find_injectables("tests.unit.test_injectables")
catalog = InjectableCatalog(registrations)

# Create a new lifetime scope and create a child lifetime scope for it
parent_scope = LifetimeScope(catalog)
child_scope = parent_scope.create_child_scope()

# Resolve the same SCOPED injectable in the parent scope and the child scope
injectable1 = parent_scope.resolve(Scoped)
injectable2 = child_scope.resolve(Scoped)

# In the above case, injectable1 and injectable2 ARE NOT the same instance

# Now resolve the same injectable again in either of the scopes
injectable3 = parent_scope.resolve(Scoped) # injectable3 == injectable1, same instance
injectable4 = child_scope.resolve(Scoped) # injectable4 == injectable2, same instance
```

This feature may be used for, among other scenarios, web requests where we may want to have an isolation of instances for each individual request (`SCOPED`) but also share some instances across all of the requests (`SINGLETON`).

Resolution rules:
* `TRANSIENT` injectables will continue to work the same way.
* A `SCOPED` injectable depending on `TRANSIENT` injectables WILL cause a warning/error ("captive dependency").
* A `SINGLETON` injectable depending on `SCOPED` injectables WILL cause a warning/error ("captive dependency").