### PR TITLE
Fix injection by Protocol and ABCMeta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Welcome
 
 [![PyPI version](https://badge.fury.io/py/kanata.svg)](https://badge.fury.io/py/kanata)
+[![CodeFactor](https://www.codefactor.io/repository/github/rexor12/kanata/badge/main)](https://www.codefactor.io/repository/github/rexor12/kanata/overview/main)
+[![Shilds](https://img.shields.io/github/license/rexor12/kanata)](https://img.shields.io/github/license/rexor12/kanata)
 
 **Kanata** is a very simple dependency injection framework used for decoupling the services of your Python application's services from their dependencies. This may help with maintainability, testability and readability.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = kanata
-version = 1.0.0.0
+version = 1.0.1.0
 author = rexor12
 author_email = rrexor@gmail.com
 description = A simple dependency injection framework for Python 3 applications.

--- a/tests/unit/test_injectables/__init__.py
+++ b/tests/unit/test_injectables/__init__.py
@@ -7,6 +7,9 @@ from .itransient2 import ITransient2
 from .iunused import IUnused
 from .missing_multiple_dependencies import MissingMultipleDependencies
 from .missing_single_dependency import MissingSingleDependency
+from .protocol_dependent import ProtocolDependent
+from .protocol_impl import ProtocolImpl
+from .protocol_interface import ProtocolInterface
 from .root import Root
 from .scoped import Scoped
 from .scoped_to_transient_dependency import ScopedToTransientDependency

--- a/tests/unit/test_injectables/protocol_dependent.py
+++ b/tests/unit/test_injectables/protocol_dependent.py
@@ -1,0 +1,8 @@
+from .inon_dependee import INonDependee
+from .protocol_interface import ProtocolInterface
+from kanata.decorators import injectable
+
+@injectable(INonDependee)
+class ProtocolDependent(INonDependee):
+    def __init__(self, protocol_impl: ProtocolInterface) -> None:
+        self.injected = protocol_impl

--- a/tests/unit/test_injectables/protocol_impl.py
+++ b/tests/unit/test_injectables/protocol_impl.py
@@ -1,0 +1,6 @@
+from .protocol_interface import ProtocolInterface
+from kanata.decorators import injectable
+
+@injectable(ProtocolInterface)
+class ProtocolImpl(ProtocolInterface):
+    """A class that implements ProtocolInterface."""

--- a/tests/unit/test_injectables/protocol_interface.py
+++ b/tests/unit/test_injectables/protocol_interface.py
@@ -1,0 +1,4 @@
+from typing import Protocol
+
+class ProtocolInterface(Protocol):
+    """Interface for an injectable defined via Protocol."""

--- a/tests/unit/test_lifetime_scope.py
+++ b/tests/unit/test_lifetime_scope.py
@@ -1,7 +1,7 @@
 from .test_injectables import (
     MissingMultipleDependencies, MissingSingleDependency, Scoped, ScopedToTransientDependency,
     Singleton, SingletonToScopedDependency, SingletonToTransientDependency, Root,
-    Transient1, Transient2
+    Transient1, Transient2, ProtocolImpl, ProtocolDependent
 )
 from kanata import InjectableCatalog, LifetimeScope, find_injectables
 from kanata.exceptions import DependencyResolutionException
@@ -227,6 +227,21 @@ class LifetimeScopeTests(unittest.TestCase):
         child_scoped = child_scope.resolve(Scoped)
 
         self.assertNotEqual(parent_scoped, child_scoped)
+
+    def test_resolve_should_resolve_by_protocol(self):
+        """Asserts that the lifetime scope correctly resolves a type
+        that implements a protocol.
+        """
+
+        registrations = find_injectables("tests.unit.test_injectables")
+        catalog = InjectableCatalog(registrations)
+        scope = LifetimeScope(catalog)
+
+        instance = scope.resolve(ProtocolDependent)
+
+        self.assertIsNotNone(instance)
+        self.assertIsInstance(instance, ProtocolDependent)
+        self.assertIsInstance(instance.injected, ProtocolImpl)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_service_discovery.py
+++ b/tests/unit/test_service_discovery.py
@@ -1,9 +1,10 @@
 from kanata import find_injectables
 from tests.sdk import assert_contains_all, first
 from tests.unit.test_injectables import (
-    INonDependee, IRoot, IScoped, ISingleton, ITransient1, ITransient2, SingletonToScopedDependency,
-    SingletonToTransientDependency, MissingMultipleDependencies, MissingSingleDependency,
-    Root, Scoped, Singleton, Transient1, Transient2, ScopedToTransientDependency
+    INonDependee, IRoot, IScoped, ISingleton, ITransient1, ITransient2,
+    SingletonToScopedDependency, SingletonToTransientDependency, MissingMultipleDependencies,
+    MissingSingleDependency, ProtocolDependent, ProtocolImpl, ProtocolInterface, Root,
+    Scoped, Singleton, Transient1, Transient2, ScopedToTransientDependency
 )
 from typing import Any, Dict, Tuple, Type
 
@@ -25,7 +26,9 @@ class ServiceDiscoveryTests(unittest.TestCase):
             Scoped: (IScoped,),
             ScopedToTransientDependency: (INonDependee,),
             SingletonToScopedDependency: (INonDependee,),
-            SingletonToTransientDependency: (INonDependee,)
+            SingletonToTransientDependency: (INonDependee,),
+            ProtocolImpl: (ProtocolInterface,),
+            ProtocolDependent: (INonDependee,)
         }
 
         registrations = find_injectables("tests.unit.test_injectables")


### PR DESCRIPTION
Fixes an issue where types that are exposed via a type that subclasses Protocol or specifies ABCMeta as its metaclass isn't resolved correctly due to having an `__origin__` attribute that isn't a Tuple.