### PR TITLE
Implement custom resolver, separate concerns

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ As constructor (or `__init__(...)` in Python) injection is used, you need to def
 
 ```py
 from kanata.decorators import injectable
-from typing import Tuple
 
 @injectable(IMyInterface):
 class MyClass(IMyInterface):
@@ -74,7 +73,7 @@ class MyClass(IMyInterface):
         self,
         dependency1: IDependency1,
         dependency2: IDependency2,
-        multiple_dependencies: Tuple[IDependency3, ...]):
+        multiple_dependencies: tuple[IDependency3, ...]):
         ...
 ```
 

--- a/samples/calculator/main.py
+++ b/samples/calculator/main.py
@@ -1,5 +1,6 @@
+from kanata import LifetimeScope, find_injectables
+from kanata.catalogs import InjectableCatalog
 from .calculator import Calculator
-from kanata import InjectableCatalog, LifetimeScope, find_injectables
 
 def run() -> None:
     """Runs the sample."""

--- a/src/kanata/__init__.py
+++ b/src/kanata/__init__.py
@@ -1,7 +1,5 @@
 """Quick access to the core functionality."""
 
-from .iinjectable_catalog import IInjectableCatalog
 from .ilifetime_scope import ILifetimeScope, TInjectable
-from .injectable_catalog import InjectableCatalog
 from .injectable_discovery import find_injectables
 from .lifetime_scope import LifetimeScope

--- a/src/kanata/catalogs/__init__.py
+++ b/src/kanata/catalogs/__init__.py
@@ -1,0 +1,2 @@
+from .iinjectable_catalog import IInjectableCatalog
+from .injectable_catalog import InjectableCatalog

--- a/src/kanata/catalogs/iinjectable_catalog.py
+++ b/src/kanata/catalogs/iinjectable_catalog.py
@@ -1,6 +1,6 @@
-from typing import Any, Protocol, TypeVar
+from typing import Protocol, TypeVar
 
-from .models import InjectableRegistration
+from kanata.models import InjectableRegistration
 
 T = TypeVar("T")
 
@@ -17,11 +17,11 @@ class IInjectableCatalog(Protocol):
 
     def get_registrations_by_contract(
         self,
-        contract: type[Any]) -> tuple[InjectableRegistration, ...]:
+        contract: type) -> tuple[InjectableRegistration, ...]:
         """Gets the registrations associated to the specified contract.
 
         :param contract: The contract for which to get the registrations.
-        :type contract: type[Any]
+        :type contract: type
         :return: The registrations associated to the contract.
         :rtype: tuple[InjectableRegistration, ...]
         """
@@ -29,11 +29,11 @@ class IInjectableCatalog(Protocol):
 
     def get_registration_by_injectable(
         self,
-        injectable: type[Any]) -> InjectableRegistration | None:
+        injectable: type) -> InjectableRegistration | None:
         """Gets the registration associated to the specified injectable.
 
         :param injectable: The injectable for which to get the registration.
-        :type injectable: type[Any]
+        :type injectable: type
         :return: If exists, the registration associated to the injectable.
         :rtype: InjectableRegistration | None
         """

--- a/src/kanata/catalogs/injectable_catalog.py
+++ b/src/kanata/catalogs/injectable_catalog.py
@@ -1,16 +1,15 @@
 from collections.abc import Iterable
-from typing import Any
 
+from kanata.models import InjectableRegistration
 from kanata.utils import get_or_add
 from .iinjectable_catalog import IInjectableCatalog
-from .models import InjectableRegistration
 
 class InjectableCatalog(IInjectableCatalog):
     """Provides access to information about the known injectables."""
 
     def __init__(self, registrations: Iterable[InjectableRegistration]) -> None:
-        self.__registrations_by_contract: dict[type[Any], list[InjectableRegistration]] = {}
-        self.__registrations_by_injectable: dict[type[Any], InjectableRegistration] = {}
+        self.__registrations_by_contract: dict[type, list[InjectableRegistration]] = {}
+        self.__registrations_by_injectable: dict[type, InjectableRegistration] = {}
         self.__build_registration_maps(registrations)
 
     def get_registrations(self) -> tuple[InjectableRegistration, ...]:
@@ -18,12 +17,14 @@ class InjectableCatalog(IInjectableCatalog):
 
     def get_registrations_by_contract(
         self,
-        contract: type[Any]) -> tuple[InjectableRegistration, ...]:
+        contract: type
+    ) -> tuple[InjectableRegistration, ...]:
         return tuple(self.__registrations_by_contract.get(contract, []))
 
     def get_registration_by_injectable(
         self,
-        injectable: type[Any]) -> InjectableRegistration | None:
+        injectable: type
+    ) -> InjectableRegistration | None:
         return self.__registrations_by_injectable.get(injectable, None)
 
     def __build_registration_maps(self, registrations: Iterable[InjectableRegistration]) -> None:

--- a/src/kanata/decorators/injectable.py
+++ b/src/kanata/decorators/injectable.py
@@ -1,16 +1,16 @@
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import TypeVar
 
 from kanata.models import InjectableRegistration
 from kanata.utils import get_or_add_attribute
 
 T = TypeVar("T")
 
-def injectable(contract_type: type[Any]) -> Callable[[type[T]], type[T]]:
+def injectable(contract_type: type) -> Callable[[type[T]], type[T]]:
     """Marks a class as an injectable.
 
     :param contract_type: The type of the contract by which an instance of the object is injectable.
-    :type contract_type: type[Any]
+    :type contract_type: type
     :return: A decorator that returns the same class that it decorates.
     :rtype: Callable[[type[T]], type[T]]
     """

--- a/src/kanata/exceptions/dependency_resolution_exception.py
+++ b/src/kanata/exceptions/dependency_resolution_exception.py
@@ -1,29 +1,28 @@
-from typing import Any
-
 class DependencyResolutionException(Exception):
     """Raised when dependency resolution fails."""
 
     def __init__(
         self,
-        related_type: type[Any] | None = None,
-        message: str | None = None) -> None:
+        related_type: type | None = None,
+        message: str | None = None
+    ) -> None:
         """Initializes a new instance.
 
         :param related_type: An optional type related to the exception, defaults to None.
-        :type related_type: type[Any], optional
+        :type related_type: type, optional
         :param message: An optional message that describes the problem, defaults to None.
         :type message: str, optional
         """
 
         super().__init__(message)
-        self.__related_type: type[Any] | None = related_type
+        self.__related_type = related_type
 
     @property
-    def related_type(self) -> type[Any] | None:
+    def related_type(self) -> type | None:
         """Gets the type related to the exception.
 
         :return: The type related to the exception.
-        :rtype: type[Any] | None
+        :rtype: type | None
         """
 
         return self.__related_type

--- a/src/kanata/models/__init__.py
+++ b/src/kanata/models/__init__.py
@@ -1,5 +1,6 @@
 """Models."""
 
+from .iinstance_collection import IInstanceCollection
 from .injectable_registration import InjectableRegistration
 from .injectable_scope_type import InjectableScopeType
-from .lifetime_scope_options import LifetimeScopeOptions
+from .instance_collection import InstanceCollection

--- a/src/kanata/models/iinstance_collection.py
+++ b/src/kanata/models/iinstance_collection.py
@@ -1,0 +1,14 @@
+from collections.abc import Generator
+from typing import Any, Protocol
+
+from .injectable_scope_type import InjectableScopeType
+
+class IInstanceCollection(Protocol):
+    """Interface for a resolved instance collection."""
+
+    def get_instances_by_contract(
+        self,
+        contract_type: type,
+        scope_type: InjectableScopeType | None = None
+    ) -> Generator[Any, None, None]:
+        ...

--- a/src/kanata/models/injectable_registration.py
+++ b/src/kanata/models/injectable_registration.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, ClassVar
+from typing import ClassVar
 
 from .injectable_scope_type import InjectableScopeType
 
@@ -11,10 +11,10 @@ class InjectableRegistration:
     """The name of the property used to hold the list
     of registration objects attached to an injectable type."""
 
-    injectable_type: type[Any]
+    injectable_type: type
     """Gets or sets the type of the injectable object."""
 
-    contract_types: set[type[Any]] = field(default_factory=set)
+    contract_types: set[type] = field(default_factory=set)
     """Gets or sets the types of the contracts by which an instance of the object is injectable."""
 
     scope: InjectableScopeType = InjectableScopeType.TRANSIENT

--- a/src/kanata/models/instance_collection.py
+++ b/src/kanata/models/instance_collection.py
@@ -1,0 +1,38 @@
+from collections.abc import Generator
+from typing import Any
+
+from .iinstance_collection import IInstanceCollection
+from .injectable_scope_type import InjectableScopeType
+
+class InstanceCollection(IInstanceCollection):
+    def __init__(self) -> None:
+        self.__instances = dict[InjectableScopeType, dict[type, set]]()
+
+    def get_instances_by_contract(
+        self,
+        contract_type: type,
+        scope_type: InjectableScopeType | None = None
+    ) -> Generator[Any, None, None]:
+        if scope_type is None:
+            for injectables_by_contract in self.__instances.values():
+                for instance in injectables_by_contract.get(contract_type, ()):
+                    yield instance
+            return
+
+        if not (injectables_by_contract := self.__instances.get(scope_type)):
+            return
+
+        for instance in injectables_by_contract.get(contract_type, tuple()):
+            yield instance
+
+    def add_instance(
+        self,
+        scope_type: InjectableScopeType,
+        injectable_type: type,
+        instance: Any
+    ) -> None:
+        if not (instances_by_scope := self.__instances.get(scope_type)):
+            self.__instances[scope_type] = instances_by_scope = {}
+        if not (instances := instances_by_scope.get(injectable_type)):
+            instances_by_scope[injectable_type] = instances = set()
+        instances.add(instance)

--- a/src/kanata/models/instance_collection.py
+++ b/src/kanata/models/instance_collection.py
@@ -15,15 +15,13 @@ class InstanceCollection(IInstanceCollection):
     ) -> Generator[Any, None, None]:
         if scope_type is None:
             for injectables_by_contract in self.__instances.values():
-                for instance in injectables_by_contract.get(contract_type, ()):
-                    yield instance
+                yield from injectables_by_contract.get(contract_type, ())
             return
 
         if not (injectables_by_contract := self.__instances.get(scope_type)):
             return
 
-        for instance in injectables_by_contract.get(contract_type, tuple()):
-            yield instance
+        yield from injectables_by_contract.get(contract_type, tuple())
 
     def add_instance(
         self,

--- a/src/kanata/resolvers/__init__.py
+++ b/src/kanata/resolvers/__init__.py
@@ -1,0 +1,4 @@
+from .default_resolver import DefaultResolver
+from .default_resolver_options import DefaultResolverOptions
+from .iresolver import IResolver
+from .resolver_base import ResolverBase

--- a/src/kanata/resolvers/default_resolver.py
+++ b/src/kanata/resolvers/default_resolver.py
@@ -1,0 +1,48 @@
+from typing import TypeVar
+
+import structlog
+
+from kanata.catalogs import IInjectableCatalog
+from kanata.constants import LOGGER_NAME
+from kanata.exceptions import DependencyResolutionException
+from kanata.models import IInstanceCollection, InjectableScopeType
+from .default_resolver_options import DefaultResolverOptions
+from .resolver_base import ResolverBase
+
+TInjectable = TypeVar("TInjectable")
+
+class DefaultResolver(ResolverBase):
+    """Default implementation of a resolver."""
+
+    def __init__(
+        self,
+        options: DefaultResolverOptions | None = None
+    ) -> None:
+        super().__init__()
+        self.__options = options or DefaultResolverOptions()
+        self.__log = structlog.get_logger(logger_name=LOGGER_NAME)
+
+    def resolve(
+        self,
+        catalog: IInjectableCatalog,
+        instances: IInstanceCollection,
+        injectable: type[TInjectable],
+        scope_type: InjectableScopeType
+    ) -> TInjectable:
+        return injectable(*self._get_dependencies(catalog, instances, injectable, scope_type))
+
+    def _on_captive_dependency_detected(
+        self,
+        injectable: type,
+        contract: type
+    ) -> None:
+        # Unless turned off, issue a warning, because a captive dependency
+        # may be the result of a coding error, as it's generally undesirable.
+        error_message = (
+            "Detected captive dependency."
+            f" Singleton '{injectable}' depends on transient '{contract}'."
+        )
+        if not self.__options.suppress_captive_dependency_warnings:
+            self.__log.warn(error_message)
+        if self.__options.raise_on_captive_dependency:
+            raise DependencyResolutionException(injectable, error_message)

--- a/src/kanata/resolvers/default_resolver_options.py
+++ b/src/kanata/resolvers/default_resolver_options.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 
 @dataclass
-class LifetimeScopeOptions:
-    """Holds options for a lifetime scope."""
+class DefaultResolverOptions:
+    """Holds options for a default resolver."""
 
     suppress_captive_dependency_warnings: bool = False
     """Gets or sets whether to suppress warning logs about captive dependencies."""

--- a/src/kanata/resolvers/iresolver.py
+++ b/src/kanata/resolvers/iresolver.py
@@ -1,0 +1,31 @@
+from typing import Protocol, TypeVar
+
+from kanata.catalogs import IInjectableCatalog
+from kanata.models import IInstanceCollection, InjectableScopeType
+
+TInjectable = TypeVar("TInjectable")
+
+class IResolver(Protocol):
+    """Interface for a service that can resolve instances of injectables."""
+
+    def resolve(
+        self,
+        catalog: IInjectableCatalog,
+        instances: IInstanceCollection,
+        injectable: type[TInjectable],
+        scope_type: InjectableScopeType
+    ) -> TInjectable:
+        """Resolves an instance of a specific injectable.
+
+        :param catalog: The catalog of injectables.
+        :type catalog: IInjectableCatalog
+        :param instances: The already resolved instances of injectables.
+        :type instances: IInstanceCollection
+        :param injectable: The type of the injectable to be resolved.
+        :type injectable: type[TInjectable]
+        :param scope_type: The scope for which to resolve the injectable.
+        :type scope_type: InjectableScopeType
+        :return: The resolved injectable instance.
+        :rtype: TInjectable
+        """
+        ...

--- a/src/kanata/resolvers/resolver_base.py
+++ b/src/kanata/resolvers/resolver_base.py
@@ -1,0 +1,120 @@
+from abc import ABC, abstractmethod
+from typing import Any, TypeVar
+
+from kanata.catalogs import IInjectableCatalog
+from kanata.exceptions import DependencyResolutionException
+from kanata.models import IInstanceCollection, InjectableScopeType
+from kanata.utils import get_dependent_contracts
+from .iresolver import IResolver
+
+TInjectable = TypeVar("TInjectable")
+
+_SCOPE_TYPE_RANKS: dict[InjectableScopeType, int] = {
+    InjectableScopeType.TRANSIENT: 0,
+    InjectableScopeType.SCOPED: 1,
+    InjectableScopeType.SINGLETON: 2
+}
+
+class ResolverBase(ABC, IResolver):
+    """Abstract base class for a resolver."""
+
+    @abstractmethod
+    def resolve(
+        self,
+        catalog: IInjectableCatalog,
+        instances: IInstanceCollection,
+        injectable: type[TInjectable],
+        scope_type: InjectableScopeType
+    ) -> TInjectable:
+        ...
+
+    @staticmethod
+    def _is_captive_dependency(
+        dependee_scope: InjectableScopeType,
+        dependent_scope: InjectableScopeType
+    ) -> bool:
+        """Determines if the dependee and dependent scopes
+        result in a captive dependency.
+
+        :param dependee_scope: The scope of the dependee.
+        :type dependee_scope: InjectableScopeType
+        :param dependent_scope: The scope of the dependent.
+        :type dependent_scope: InjectableScopeType
+        :return: True, if a captive dependency is detected.
+        :rtype: bool
+        """
+
+        ranked_scopes = sorted(
+            (dependee_scope, dependent_scope),
+            key=lambda i: _SCOPE_TYPE_RANKS[i]
+        )
+        return ranked_scopes[0] != dependee_scope
+
+    def _on_captive_dependency_detected(
+        self,
+        injectable: type,
+        contract: type
+    ) -> None:
+        """Invoked when a captive dependency is detected
+        so that the resolver can handle the situation.
+
+        This method should be overridden by subclasses
+        and it does nothing by default.
+
+        :param injectable: The type of the causing injectable.
+        :type injectable: type
+        :param contract: The type of the dependent contract.
+        :type contract: type
+        """
+
+    def _get_dependencies(
+        self,
+        catalog: IInjectableCatalog,
+        instances: IInstanceCollection,
+        injectable: type,
+        dependee_scope: InjectableScopeType
+    ) -> list[Any]:
+        """Gets the dependencies of the specified injectable.
+
+        :param catalog: The catalog of injectables.
+        :type catalog: IInjectableCatalog
+        :param instances: The already resolved instances of injectables.
+        :type instances: IInstanceCollection
+        :param injectable: The type of the injectable for which to get the dependencies.
+        :type injectable: type
+        :param dependee_scope: The scope of the dependee.
+        :type dependee_scope: InjectableScopeType
+        :raises DependencyResolutionException: Raised when a dependency cannot be satisfied.
+        :return: The list of dependencies.
+        :rtype: list[Any]
+        """
+
+        dependent_contracts = get_dependent_contracts(injectable)
+        dependent_injectables = []
+        for dependent_contract, is_multi in dependent_contracts:
+            registrations = catalog.get_registrations_by_contract(dependent_contract)
+            candidate_instances = []
+            for registration in registrations:
+                if ResolverBase._is_captive_dependency(dependee_scope, registration.scope):
+                    self._on_captive_dependency_detected(injectable, dependent_contract)
+
+                candidate_instances.extend(
+                    instances.get_instances_by_contract(
+                        registration.injectable_type,
+                        registration.scope
+                    )
+                )
+
+            if is_multi:
+                dependent_injectables.append(tuple(candidate_instances))
+            elif len(candidate_instances) > 0:
+                dependent_injectables.append(candidate_instances[0])
+            else:
+                raise DependencyResolutionException(
+                    injectable,
+                    (
+                        "Cannot satisfy the dependency"
+                        f"of '{injectable}' on '{dependent_contract}'."
+                    )
+                )
+        return dependent_injectables

--- a/src/kanata/utils/__init__.py
+++ b/src/kanata/utils/__init__.py
@@ -1,4 +1,4 @@
 """Utilities for various types."""
 
 from .dict_utils import get_or_add
-from .type_utils import get_or_add_attribute
+from .type_utils import get_dependent_contracts, get_or_add_attribute

--- a/src/kanata/utils/type_utils.py
+++ b/src/kanata/utils/type_utils.py
@@ -1,12 +1,15 @@
 """Utility methods for types."""
 
-from collections.abc import Callable
-from typing import Any, TypeVar
+import inspect
+from collections.abc import Callable, Generator
+from typing import TypeVar, get_args
+
+from kanata.exceptions import DependencyResolutionException
 
 TAttribute = TypeVar("TAttribute")
 
 def get_or_add_attribute(
-    clazz: type[Any],
+    clazz: type,
     name: str,
     default_factory: Callable[[], TAttribute]
 ) -> TAttribute:
@@ -14,7 +17,7 @@ def get_or_add_attribute(
     otherwise adds it with the value determined by the specified value factory.
 
     :param clazz: The type of the class.
-    :type clazz: type[Any]
+    :type clazz: type
     :param name: The name of the attribute.
     :type name: str
     :param default_factory: A value factory for the default value to add, if needed.
@@ -28,3 +31,41 @@ def get_or_add_attribute(
         attribute = default_factory()
         setattr(clazz, name, attribute)
     return attribute
+
+def get_dependent_contracts(
+    injectable: type) -> Generator[tuple[type, bool], None, None]:
+    constructor = getattr(injectable, "__init__", None)
+    if not constructor or not callable(constructor):
+        raise DependencyResolutionException(injectable, "Invalid constructor.")
+    signature = inspect.signature(constructor)
+    for name, descriptor in signature.parameters.items():
+        if name in ("self", "args", "kwargs"):
+            continue
+        if descriptor.annotation == inspect.Parameter.empty:
+            raise DependencyResolutionException(
+                injectable,
+                f"The initializer of '{injectable}' is missing annotations."
+            )
+        yield __unpack_dependent_intf(descriptor.annotation)
+
+def __unpack_dependent_intf(contract: type) -> tuple[type, bool]:
+    if (
+        getattr(contract, "_is_protocol", False) # typing.Protocol
+        or getattr(contract, "__abstractmethods__", None) # abc.ABCMeta
+        or (origin := getattr(contract, "__origin__", None)) is None
+    ):
+        return (contract, False)
+
+    if origin is not tuple:
+        raise DependencyResolutionException(
+            contract,
+            f"Expected a tuple, but got {origin} for contract {contract}."
+        )
+
+    args = get_args(contract)
+    if len(args) != 2 or args[-1] != Ellipsis:
+        raise DependencyResolutionException(
+            contract,
+            "Expected a tuple with two arguments, the second being an ellipsis."
+        )
+    return (args[0], True)

--- a/tests/unit/test_injectable_catalog.py
+++ b/tests/unit/test_injectable_catalog.py
@@ -1,8 +1,10 @@
-from .test_injectables import ITransient1, Singleton, Transient1
-from kanata import InjectableCatalog, find_injectables
+import unittest
+
 from tests.sdk import assert_contains, assert_contains_all
 
-import unittest
+from kanata import find_injectables
+from kanata.catalogs import InjectableCatalog
+from .test_injectables import ITransient1, Singleton, Transient1
 
 class InjectableCatalogTests(unittest.TestCase):
     """Unit tests for InjectableCatalog."""

--- a/tests/unit/test_lifetime_scope.py
+++ b/tests/unit/test_lifetime_scope.py
@@ -1,14 +1,19 @@
-from .test_injectables import (
-    MissingMultipleDependencies, MissingSingleDependency, Scoped, ScopedToTransientDependency,
-    Singleton, SingletonToScopedDependency, SingletonToTransientDependency, Root,
-    Transient1, Transient2, ProtocolImpl, ProtocolDependent
-)
-from kanata import InjectableCatalog, LifetimeScope, find_injectables
-from kanata.exceptions import DependencyResolutionException
-from kanata.models import LifetimeScopeOptions
+import unittest
+from typing import TypeVar
+
 from tests.sdk import assert_contains, assert_contains_unique
 
-import unittest
+from kanata import LifetimeScope, find_injectables
+from kanata.catalogs import InjectableCatalog
+from kanata.exceptions import DependencyResolutionException
+from kanata.resolvers import DefaultResolver, DefaultResolverOptions
+from .test_injectables import (
+    MissingMultipleDependencies, MissingSingleDependency, ProtocolDependent, ProtocolImpl, Root,
+    Scoped, ScopedToTransientDependency, Singleton, SingletonToScopedDependency,
+    SingletonToTransientDependency, Transient1, Transient2
+)
+
+TInjectable = TypeVar("TInjectable")
 
 class LifetimeScopeTests(unittest.TestCase):
     """Unit tests for lifetime scopes."""
@@ -117,9 +122,9 @@ class LifetimeScopeTests(unittest.TestCase):
         """
 
         registrations = find_injectables("tests.unit.test_injectables")
-        options = LifetimeScopeOptions(raise_on_captive_dependency=False)
+        options = DefaultResolverOptions(raise_on_captive_dependency=False)
         catalog = InjectableCatalog(registrations)
-        scope = LifetimeScope(catalog, options)
+        scope = LifetimeScope(catalog, (DefaultResolver(options),))
 
         instance = scope.resolve(SingletonToTransientDependency)
 
@@ -131,9 +136,9 @@ class LifetimeScopeTests(unittest.TestCase):
         """
 
         registrations = find_injectables("tests.unit.test_injectables")
-        options = LifetimeScopeOptions(raise_on_captive_dependency=False)
+        options = DefaultResolverOptions(raise_on_captive_dependency=False)
         catalog = InjectableCatalog(registrations)
-        scope = LifetimeScope(catalog, options)
+        scope = LifetimeScope(catalog, (DefaultResolver(options),))
 
         instance = scope.resolve(SingletonToScopedDependency)
 
@@ -145,9 +150,9 @@ class LifetimeScopeTests(unittest.TestCase):
         """
 
         registrations = find_injectables("tests.unit.test_injectables")
-        options = LifetimeScopeOptions(raise_on_captive_dependency=False)
+        options = DefaultResolverOptions(raise_on_captive_dependency=False)
         catalog = InjectableCatalog(registrations)
-        scope = LifetimeScope(catalog, options)
+        scope = LifetimeScope(catalog, (DefaultResolver(options),))
 
         instance = scope.resolve(ScopedToTransientDependency)
 

--- a/tests/unit/test_service_discovery.py
+++ b/tests/unit/test_service_discovery.py
@@ -1,5 +1,4 @@
 import unittest
-from typing import Any
 
 from tests.sdk import assert_contains_all, first
 from tests.unit.test_injectables import (
@@ -17,7 +16,7 @@ class ServiceDiscoveryTests(unittest.TestCase):
     def test_find_injectables_should_find_all_injectables_recursively(self):
         """Asserts that all injectables are discovered in a specific module."""
 
-        expected_types: dict[type[Any], tuple[type[Any], ...]] = {
+        expected_types: dict[type, tuple[type, ...]] = {
             Root: (IRoot,),
             Singleton: (ITransient1, ITransient2, ISingleton),
             Transient1: (ITransient1,),


### PR DESCRIPTION
`DefaultResolver` is a good example for implementing a custom resolver. This one is used by default - hence the name - and will just return the new instance with the dependencies injected (according to the already existing behavior).

Custom resolvers can be passed to the `LifetimeScope`:
```py
registrations = find_injectables("tests.unit.test_injectables")
catalog = InjectableCatalog(registrations)

# Passed as a tuple:
scope = LifetimeScope(catalog, (DefaultResolver(),))
```

Closes #16 