### PR TITLE
Implement support for instance registration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Unit tests",
+            "type": "python",
+            "request": "launch",
+            "module": "unittest",
+            "args": ["-v"],
+            "justMyCode": true
+        }
+    ]
+}

--- a/samples/calculator/main.py
+++ b/samples/calculator/main.py
@@ -1,5 +1,6 @@
 from kanata import LifetimeScope, find_injectables
 from kanata.catalogs import InjectableCatalog
+from kanata.models import InjectableInstanceRegistration, InjectableTypeRegistration
 from .calculator import Calculator
 
 def run() -> None:
@@ -9,7 +10,14 @@ def run() -> None:
     catalog = InjectableCatalog(find_injectables("samples.calculator"))
     print("Found the following registrations:")
     for registration in catalog.get_registrations():
-        print(f"{registration.injectable_type} registered as: {registration.contract_types}")
+        match registration:
+            case InjectableTypeRegistration():
+                injectable_type = registration.injectable_type
+            case InjectableInstanceRegistration():
+                injectable_type = type(registration.injectable_instance)
+            case _:
+                raise ValueError(f"Unknown registration type '{type(registration)}'.")
+        print(f"{injectable_type} registered as: {registration.contract_types}")
 
     # Create a lifetime scope that will hold our injectable instances.
     scope = LifetimeScope(catalog)

--- a/src/kanata/catalogs/__init__.py
+++ b/src/kanata/catalogs/__init__.py
@@ -1,2 +1,3 @@
 from .iinjectable_catalog import IInjectableCatalog
 from .injectable_catalog import InjectableCatalog
+from .injectable_catalog_builder import InjectableCatalogBuilder

--- a/src/kanata/catalogs/injectable_catalog.py
+++ b/src/kanata/catalogs/injectable_catalog.py
@@ -1,6 +1,9 @@
 from collections.abc import Iterable
 
-from kanata.models import InjectableRegistration
+from kanata.exceptions import InjectableRegistrationException
+from kanata.models import (
+    InjectableInstanceRegistration, InjectableRegistration, InjectableTypeRegistration
+)
 from kanata.utils import get_or_add
 from .iinjectable_catalog import IInjectableCatalog
 
@@ -36,4 +39,15 @@ class InjectableCatalog(IInjectableCatalog):
                     lambda _: [])
                 by_injectables.append(registration)
 
-            self.__registrations_by_injectable[registration.injectable_type] = registration
+            match registration:
+                case InjectableTypeRegistration():
+                    key = registration.injectable_type
+                case InjectableInstanceRegistration():
+                    key = type(registration.injectable_instance)
+                case _:
+                    raise InjectableRegistrationException(
+                        type(registration),
+                        "Unsupported type of injectable registration."
+                    )
+
+            self.__registrations_by_injectable[key] = registration

--- a/src/kanata/catalogs/injectable_catalog_builder.py
+++ b/src/kanata/catalogs/injectable_catalog_builder.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from kanata import find_injectables
+from kanata.models import (
+    InjectableInstanceRegistration, InjectableRegistration, InjectableScopeType,
+    InjectableTypeRegistration
+)
+from .iinjectable_catalog import IInjectableCatalog
+from .injectable_catalog import InjectableCatalog
+
+class InjectableCatalogBuilder:
+    """An injectable catalog builder."""
+
+    def __init__(self) -> None:
+        self.__registrations = list[InjectableRegistration]()
+
+    def add_module(self, module_name: str) -> InjectableCatalogBuilder:
+        """Discovers the injectable registrations from the module with the specified name.
+
+        :param module_name: The name of the module to explore.
+        :type module_name: str
+        :return: The same instance of the builder.
+        :rtype: InjectableCatalogBuilder
+        """
+
+        self.__registrations.extend(find_injectables(module_name))
+        return self
+
+    def register_instance(
+        self,
+        instance: Any,
+        contract_types: Iterable[type]
+    ) -> InjectableCatalogBuilder:
+        """Registers the specified instance as an injectable.
+
+        :param instance: The instance to be registered.
+        :type instance: Any
+        :param contract_types: The contracts by which to register the instance.
+        :type contract_types: Iterable[type]
+        :return: The same instance of the builder.
+        :rtype: InjectableCatalogBuilder
+        """
+
+        # TODO https://github.com/PyCQA/pylint/issues/6550
+        self.__registrations.append(
+            InjectableInstanceRegistration( # pylint: disable=unexpected-keyword-arg
+                contract_types=set(contract_types),
+                injectable_instance=instance
+            )
+        )
+        return self
+
+    def register_type(
+        self,
+        injectable_type: type,
+        contract_types: Iterable[type],
+        scope_type: InjectableScopeType = InjectableScopeType.TRANSIENT
+    ) -> InjectableCatalogBuilder:
+        """Registers the specified type as an injectable.
+
+        :param injectable_type: The type to be registered.
+        :type injectable_type: type
+        :param contract_types: The contracts by which to register the type.
+        :type contract_types: Iterable[type]
+        :param scope_type: The injectable scope, defaults to InjectableScopeType.TRANSIENT
+        :type scope_type: InjectableScopeType, optional
+        :return: The same instance of the builder.
+        :rtype: InjectableCatalogBuilder
+        """
+
+        # TODO https://github.com/PyCQA/pylint/issues/6550
+        self.__registrations.append(
+            InjectableTypeRegistration( # pylint: disable=unexpected-keyword-arg
+                contract_types=set(contract_types),
+                injectable_type=injectable_type,
+                scope=scope_type
+            )
+        )
+        return self
+
+    def build(self) -> IInjectableCatalog:
+        """Builds the injectable catalog.
+
+        :return: The new instance of the injectable catalog.
+        :rtype: IInjectableCatalog
+        """
+
+        return InjectableCatalog(self.__registrations)

--- a/src/kanata/decorators/injectable.py
+++ b/src/kanata/decorators/injectable.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from typing import TypeVar
 
-from kanata.models import InjectableRegistration
+from kanata.models import InjectableTypeRegistration
 from kanata.utils import get_or_add_attribute
 
 T = TypeVar("T")
@@ -18,8 +18,10 @@ def injectable(contract_type: type) -> Callable[[type[T]], type[T]]:
     def decorator(wrapped_class: type[T]) -> type[T]:
         registration = get_or_add_attribute(
             wrapped_class,
-            InjectableRegistration.PROPERTY_NAME,
-            lambda: InjectableRegistration(wrapped_class))
+            InjectableTypeRegistration.PROPERTY_NAME,
+            # TODO https://github.com/PyCQA/pylint/issues/6550
+            lambda: InjectableTypeRegistration(injectable_type=wrapped_class) # pylint: disable=unexpected-keyword-arg
+        )
         registration.contract_types.add(contract_type)
         return wrapped_class
 

--- a/src/kanata/decorators/scope.py
+++ b/src/kanata/decorators/scope.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from typing import TypeVar
 
-from kanata.models import InjectableRegistration, InjectableScopeType
+from kanata.models import InjectableScopeType, InjectableTypeRegistration
 from kanata.utils import get_or_add_attribute
 
 T = TypeVar("T")
@@ -17,8 +17,10 @@ def scope(scope_type: InjectableScopeType) -> Callable[[type[T]], type[T]]:
     def decorator(wrapped_class: type[T]) -> type[T]:
         registration = get_or_add_attribute(
             wrapped_class,
-            InjectableRegistration.PROPERTY_NAME,
-            lambda: InjectableRegistration(wrapped_class))
+            InjectableTypeRegistration.PROPERTY_NAME,
+            # TODO https://github.com/PyCQA/pylint/issues/6550
+            lambda: InjectableTypeRegistration(injectable_type=wrapped_class) # pylint: disable=unexpected-keyword-arg
+        )
         registration.scope = scope_type
         return wrapped_class
 

--- a/src/kanata/exceptions/__init__.py
+++ b/src/kanata/exceptions/__init__.py
@@ -2,3 +2,4 @@
 
 from .argument_exception import ArgumentException
 from .dependency_resolution_exception import DependencyResolutionException
+from .injectable_registration_exception import InjectableRegistrationException

--- a/src/kanata/exceptions/injectable_registration_exception.py
+++ b/src/kanata/exceptions/injectable_registration_exception.py
@@ -1,0 +1,28 @@
+class InjectableRegistrationException(Exception):
+    """Raised when registering an injectable fails."""
+
+    def __init__(
+        self,
+        related_type: type | None = None,
+        message: str | None = None
+    ) -> None:
+        """Initializes a new instance.
+
+        :param related_type: An optional type related to the exception, defaults to None.
+        :type related_type: type, optional
+        :param message: An optional message that describes the problem, defaults to None.
+        :type message: str, optional
+        """
+
+        super().__init__(message)
+        self.__related_type = related_type
+
+    @property
+    def related_type(self) -> type | None:
+        """Gets the type related to the exception.
+
+        :return: The type related to the exception.
+        :rtype: type | None
+        """
+
+        return self.__related_type

--- a/src/kanata/models/__init__.py
+++ b/src/kanata/models/__init__.py
@@ -1,6 +1,8 @@
 """Models."""
 
 from .iinstance_collection import IInstanceCollection
+from .injectable_instance_registration import InjectableInstanceRegistration
 from .injectable_registration import InjectableRegistration
 from .injectable_scope_type import InjectableScopeType
+from .injectable_type_registration import InjectableTypeRegistration
 from .instance_collection import InstanceCollection

--- a/src/kanata/models/injectable_instance_registration.py
+++ b/src/kanata/models/injectable_instance_registration.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from typing import Any
+
+from .injectable_registration import InjectableRegistration
+
+@dataclass(kw_only=True)
+class InjectableInstanceRegistration(InjectableRegistration):
+    injectable_instance: Any
+    """Gets or sets the injectable instance."""

--- a/src/kanata/models/injectable_registration.py
+++ b/src/kanata/models/injectable_registration.py
@@ -1,9 +1,7 @@
 from dataclasses import dataclass, field
 from typing import ClassVar
 
-from .injectable_scope_type import InjectableScopeType
-
-@dataclass
+@dataclass(kw_only=True)
 class InjectableRegistration:
     """Holds information about the registration of an injectable type."""
 
@@ -11,19 +9,5 @@ class InjectableRegistration:
     """The name of the property used to hold the list
     of registration objects attached to an injectable type."""
 
-    injectable_type: type
-    """Gets or sets the type of the injectable object."""
-
     contract_types: set[type] = field(default_factory=set)
     """Gets or sets the types of the contracts by which an instance of the object is injectable."""
-
-    scope: InjectableScopeType = InjectableScopeType.TRANSIENT
-    """Gets or sets the lifetime scope type of the created instances."""
-
-    def __str__(self) -> str:
-        return (
-            "<InjectableRegistration"
-            f" injectable={self.injectable_type},"
-            f" contracts={len(self.contract_types)},"
-            f" scope={self.scope}>"
-        )

--- a/src/kanata/models/injectable_type_registration.py
+++ b/src/kanata/models/injectable_type_registration.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+from .injectable_registration import InjectableRegistration
+from .injectable_scope_type import InjectableScopeType
+
+@dataclass(kw_only=True)
+class InjectableTypeRegistration(InjectableRegistration):
+    injectable_type: type
+    """Gets or sets the type of the injectable object."""
+
+    scope: InjectableScopeType = InjectableScopeType.TRANSIENT
+    """Gets or sets the lifetime scope type of the created instances."""

--- a/src/kanata/models/instance_collection.py
+++ b/src/kanata/models/instance_collection.py
@@ -21,7 +21,7 @@ class InstanceCollection(IInstanceCollection):
         if not (injectables_by_contract := self.__instances.get(scope_type)):
             return
 
-        yield from injectables_by_contract.get(contract_type, tuple())
+        yield from injectables_by_contract.get(contract_type, ())
 
     def add_instance(
         self,

--- a/tests/unit/test_injectable_catalog.py
+++ b/tests/unit/test_injectable_catalog.py
@@ -1,10 +1,18 @@
 import unittest
+from typing import cast
 
 from tests.sdk import assert_contains, assert_contains_all
 
 from kanata import find_injectables
-from kanata.catalogs import InjectableCatalog
-from .test_injectables import ITransient1, Singleton, Transient1
+from kanata.catalogs import InjectableCatalog, InjectableCatalogBuilder
+from kanata.models import InjectableInstanceRegistration, InjectableTypeRegistration
+from .test_injectables import ISingleton, ITransient1, Singleton, Transient1
+
+class _TestInstanceService(ISingleton):
+    pass
+
+class _TestTransientService(Transient1):
+    pass
 
 class InjectableCatalogTests(unittest.TestCase):
     """Unit tests for InjectableCatalog."""
@@ -34,11 +42,31 @@ class InjectableCatalogTests(unittest.TestCase):
         associated to a specified contract.
         """
 
-        registrations = find_injectables("tests.unit.test_injectables")
-        catalog = InjectableCatalog(registrations)
+        instance = _TestInstanceService()
+        catalog_builder = InjectableCatalogBuilder()
+        (catalog_builder
+            .add_module("tests.unit.test_injectables")
+            .register_instance(instance, (ISingleton,))
+            .register_type(_TestTransientService, (ITransient1,))
+        )
+        catalog = catalog_builder.build()
+
         result = catalog.get_registrations_by_contract(ITransient1)
         self.assertIsNotNone(result)
-        assert_contains(result, lambda i: i.injectable_type in [Singleton, Transient1])
+        type_registrations = map(
+            lambda i: cast(InjectableTypeRegistration, i),
+            filter(lambda i: isinstance(i, InjectableTypeRegistration), result)
+        )
+        assert_contains(type_registrations, lambda i: i.injectable_type is Singleton)
+        assert_contains(type_registrations, lambda i: i.injectable_type is Transient1)
+        assert_contains(type_registrations, lambda i: i.injectable_type is _TestTransientService)
+
+        result = catalog.get_registrations_by_contract(ISingleton)
+        instance_registrations = map(
+            lambda i: cast(InjectableInstanceRegistration, i),
+            filter(lambda i: isinstance(i, InjectableInstanceRegistration), result)
+        )
+        assert_contains(instance_registrations, lambda i: isinstance(i.injectable_instance, _TestInstanceService))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_service_discovery.py
+++ b/tests/unit/test_service_discovery.py
@@ -9,6 +9,7 @@ from tests.unit.test_injectables import (
 )
 
 from kanata import find_injectables
+from kanata.models import InjectableTypeRegistration
 
 class ServiceDiscoveryTests(unittest.TestCase):
     """Unit tests for service discovery."""
@@ -35,7 +36,13 @@ class ServiceDiscoveryTests(unittest.TestCase):
 
         self.assertEqual(len(registrations), len(expected_types))
         for injectable, contracts in expected_types.items():
-            registration = first(registrations, lambda i, t=injectable: i.injectable_type == t)
+            registration = first(
+                registrations,
+                lambda i, t=injectable: (
+                    isinstance(i, InjectableTypeRegistration)
+                    and i.injectable_type == t
+                )
+            )
             self.assertEqual(len(contracts), len(registration.contract_types))
             assert_contains_all(registration.contract_types, contracts)
 


### PR DESCRIPTION
An injectable catalog builder can now be used to add registrations conveniently:
```py
from kanata.catalogs import InjectableCatalogBuilder

# create the instance we want to register
instance = _TestInstanceService()

# create a catalog builder
catalog_builder = InjectableCatalogBuilder()
(catalog_builder
    .add_module("tests.unit.test_injectables") # add all registrations from a module
    .register_instance(instance, (ISingleton,)) # register a specific instance
    .register_type(_TestTransientService, (ITransient1,)) # register a specific type
)

# create the catalog with the registrations
catalog = catalog_builder.build()
```

Closes #11 